### PR TITLE
refactor: streamline header styling and remove skip link

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,6 @@
   </head>
 
   <body>
-    <a class="skip-link" href="#main-content">Saltar al contenido principal</a>
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm">
       <div class="container-fluid">

--- a/styles.css
+++ b/styles.css
@@ -67,6 +67,8 @@ h3 {
 
 h1 {
   font-size: clamp(2rem, 1.5rem + 2vw, 3rem);
+  color: var(--color-primary);
+  font-weight: 700;
 }
 
 h2 {
@@ -91,14 +93,11 @@ html {
 }
 
 header {
-  background: linear-gradient(
-    135deg,
-    var(--color-primary),
-    var(--color-accent)
-  );
-  color: var(--color-counter-bg);
+  background-color: var(--color-background);
+  color: var(--color-text);
   text-align: center;
   padding: var(--spacing-lg) var(--spacing-md);
+  border-bottom: 2px solid var(--color-primary);
 }
 
 main {
@@ -343,21 +342,6 @@ footer p {
 :focus-visible {
   outline: var(--focus-outline);
   outline-offset: 2px;
-}
-
-.skip-link {
-  position: absolute;
-  top: 0;
-  left: 0;
-  transform: translateY(-100%);
-  background: var(--color-primary);
-  color: var(--color-counter-bg);
-  padding: var(--spacing-sm);
-  z-index: 100;
-}
-
-.skip-link:focus {
-  transform: translateY(0);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- remove skip link from top and its styles
- replace header's blue-red gradient with neutral styling and border for cleaner look
- emphasize page title with brand color and stronger font weight

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6898d4a55aa0832880fc16ec8b97dcb7