### PR TITLE
[codex] remove obsolete Node 24 forcing flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ permissions:
   contents: read
 name: CI
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 on:
   push:
     branches: [main]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,6 @@ concurrency:
 
 env:
   BUILD_PATH: "."
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build:

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -7,9 +7,6 @@ on:
 permissions:
   contents: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changed

- Removed the obsolete `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` workflow environment setting.
- Kept the repository's intentional project/runtime Node version configuration unchanged.

## Why

GitHub-hosted Actions runners now use Node 24 by default. The pre-migration forcing flag is redundant and can cause workflow failures after the migration.

## Impact

JavaScript actions use the runner's default Node 24 runtime without an obsolete override. Application runtime behavior is unchanged.

## Validation

- Workflow YAML parsed successfully.
- `git diff --check` passed.
- Confirmed the forcing flag no longer appears in `.github/`.

## Rollback

Revert this commit.
