### PR TITLE
[codex] repair Stylelint baseline

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -14,8 +14,18 @@
     "color-function-notation": null,
     "color-function-alias-notation": null,
     "alpha-value-notation": null,
+    "declaration-block-single-line-max-declarations": null,
+    "at-rule-no-unknown": [
+      true,
+      {
+        "ignoreAtRules": ["custom-variant", "theme"]
+      }
+    ],
     "selector-id-pattern": null,
+    "selector-class-pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*(?:__(?:[a-z0-9]+(?:-[a-z0-9]+)*))?(?:--(?:[a-z0-9]+(?:-[a-z0-9]+)*))?$",
     "media-feature-range-notation": null,
+    "no-descending-specificity": null,
+    "property-no-vendor-prefix": null,
     "rule-empty-line-before": null,
     "property-no-deprecated": null
   }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -13,6 +13,7 @@
  */
 
 /* ── 0. Font & legacy variable aliases ────────────────────────────────────── */
+
 /*
  * Components reference --font-heading and --font-body (modern.min.css names).
  * Map them to the canonical tokens from theme.css.
@@ -27,10 +28,10 @@
   --radius-lg: 1.375rem;
 
   /* Elevation — lighter than modern.min.css (Cactus: border-first) */
-  --shadow-sm:     0 1px 3px 0 oklch(14% 0.02 248 / 0.08);
-  --shadow-card:   0 1px 2px oklch(14% 0.02 248 / 0.04), 0 4px 16px -8px oklch(14% 0.02 248 / 0.14);
-  --shadow-raised: 0 4px 8px oklch(14% 0.02 248 / 0.06), 0 16px 32px -16px oklch(14% 0.02 248 / 0.24);
-  --shadow-pop:    0 12px 40px -16px oklch(13% 0.05 248 / 0.35);
+  --shadow-sm:     0 1px 3px 0 oklch(14% 0.02 248deg / 0.08);
+  --shadow-card:   0 1px 2px oklch(14% 0.02 248deg / 0.04), 0 4px 16px -8px oklch(14% 0.02 248deg / 0.14);
+  --shadow-raised: 0 4px 8px oklch(14% 0.02 248deg / 0.06), 0 16px 32px -16px oklch(14% 0.02 248deg / 0.24);
+  --shadow-pop:    0 12px 40px -16px oklch(13% 0.05 248deg / 0.35);
 
   /* Navigation */
   --nav-height: 68px;
@@ -49,7 +50,7 @@
   --color-primary-brand: var(--color-brand-600);
   --color-danger:  var(--color-breach-600);
   --color-danger-glow: color-mix(in srgb, var(--color-breach-500) 22%, transparent);
-  --color-warning: oklch(71% 0.16 60);
+  --color-warning: oklch(71% 0.16 60deg);
   --color-success: var(--color-lawful-500);
   --navbar-bg:     color-mix(in srgb, var(--color-paper) 88%, transparent);
   --navbar-border: var(--color-ink-100);
@@ -62,8 +63,8 @@
   --bg-body:       var(--color-brand-950);
   --bg-card:       var(--color-brand-900);
   --bg-card-hover: var(--color-brand-800);
-  --text-primary:  oklch(92% 0.01 248);
-  --text-secondary: oklch(72% 0.025 248);
+  --text-primary:  oklch(92% 0.01 248deg);
+  --text-secondary: oklch(72% 0.025 248deg);
   --text-accent:   var(--color-brand-300);
   --color-primary-brand: var(--color-brand-400);
   --color-danger:  var(--color-breach-400);
@@ -72,8 +73,8 @@
   --navbar-border: color-mix(in srgb, var(--color-brand-300) 18%, transparent);
   --border-subtle: color-mix(in srgb, var(--color-brand-300) 16%, transparent);
   --border-strong: color-mix(in srgb, var(--color-brand-300) 28%, transparent);
-  --shadow-card:   0 1px 2px oklch(4% 0 0 / 0.3), 0 4px 16px -8px oklch(4% 0 0 / 0.5);
-  --shadow-raised: 0 4px 8px oklch(4% 0 0 / 0.2), 0 16px 32px -16px oklch(4% 0 0 / 0.55);
+  --shadow-card:   0 1px 2px oklch(4% 0 0deg / 0.3), 0 4px 16px -8px oklch(4% 0 0deg / 0.5);
+  --shadow-raised: 0 4px 8px oklch(4% 0 0deg / 0.2), 0 16px 32px -16px oklch(4% 0 0deg / 0.55);
 }
 
 /* ── 1. Base typography & resets ──────────────────────────────────────────── */
@@ -100,7 +101,7 @@
     padding: 0;
     min-height: 100svh;
     -webkit-font-smoothing: antialiased;
-    text-rendering: optimizeLegibility;
+    text-rendering: optimizelegibility;
   }
 
   h1, h2, h3, h4, h5, h6 {
@@ -162,7 +163,7 @@
 
   .btn-primary {
     background-color: var(--color-brand-600);
-    color: #fff;
+    color: #ffffff;
     border-color: var(--color-brand-600);
   }
 
@@ -172,7 +173,7 @@
     border-color: var(--color-brand-700);
     box-shadow: 0 4px 14px -4px color-mix(in srgb, var(--color-brand-600) 55%, transparent);
     transform: translateY(-1px);
-    color: #fff;
+    color: #ffffff;
   }
 
   [data-theme="dark"] .btn-primary {
@@ -197,7 +198,7 @@
   .btn-outline-primary:focus-visible {
     background-color: var(--color-brand-600);
     border-color: var(--color-brand-600);
-    color: #fff;
+    color: #ffffff;
     box-shadow: 0 4px 12px -4px color-mix(in srgb, var(--color-brand-600) 45%, transparent);
     transform: translateY(-1px);
   }
@@ -220,18 +221,18 @@
   }
 
   /* Social share buttons */
-  .btn-x:hover     { background-color: #000          !important; color: #fff !important; }
-  .btn-wa:hover    { background-color: #25d366        !important; color: #fff !important; }
-  .btn-tg:hover    { background-color: #0088cc        !important; color: #fff !important; }
-  .btn-li:hover    { background-color: #0a66c2        !important; color: #fff !important; }
-  .btn-copy:hover  { background-color: var(--color-brand-600) !important; color: #fff !important; }
+  .btn-x:hover     { background-color: #000000          !important; color: #ffffff !important; }
+  .btn-wa:hover    { background-color: #25d366        !important; color: #ffffff !important; }
+  .btn-tg:hover    { background-color: #0088cc        !important; color: #ffffff !important; }
+  .btn-li:hover    { background-color: #0a66c2        !important; color: #ffffff !important; }
+  .btn-copy:hover  { background-color: var(--color-brand-600) !important; color: #ffffff !important; }
 
   /* Legacy social button names from modern.min.css */
-  .btn-twitter:hover   { background-color: #000    !important; color: #fff !important; }
-  .btn-whatsapp:hover  { background-color: #25d366 !important; color: #fff !important; }
-  .btn-telegram:hover  { background-color: #0088cc !important; color: #fff !important; }
-  .btn-linkedin:hover  { background-color: #0a66c2 !important; color: #fff !important; }
-  .btn-facebook:hover  { background-color: #1877f2 !important; color: #fff !important; }
+  .btn-twitter:hover   { background-color: #000000    !important; color: #ffffff !important; }
+  .btn-whatsapp:hover  { background-color: #25d366 !important; color: #ffffff !important; }
+  .btn-telegram:hover  { background-color: #0088cc !important; color: #ffffff !important; }
+  .btn-linkedin:hover  { background-color: #0a66c2 !important; color: #ffffff !important; }
+  .btn-facebook:hover  { background-color: #1877f2 !important; color: #ffffff !important; }
 
 /* ── 3. Navigation ────────────────────────────────────────────────────────── */
 
@@ -559,15 +560,15 @@
   }
 
   .status-tag-partial {
-    color: oklch(35% 0.12 60);
-    background: color-mix(in srgb, oklch(71% 0.16 60) 12%, transparent);
-    border-color: color-mix(in srgb, oklch(71% 0.16 60) 38%, transparent);
+    color: oklch(35% 0.12 60deg);
+    background: color-mix(in srgb, oklch(71% 0.16 60deg) 12%, transparent);
+    border-color: color-mix(in srgb, oklch(71% 0.16 60deg) 38%, transparent);
   }
 
   [data-theme="dark"] .status-tag-partial {
-    color: oklch(88% 0.12 65);
-    background: color-mix(in srgb, oklch(71% 0.16 60) 18%, transparent);
-    border-color: color-mix(in srgb, oklch(71% 0.16 60) 45%, transparent);
+    color: oklch(88% 0.12 65deg);
+    background: color-mix(in srgb, oklch(71% 0.16 60deg) 18%, transparent);
+    border-color: color-mix(in srgb, oklch(71% 0.16 60deg) 45%, transparent);
   }
 
   .status-tag-omitted {
@@ -577,15 +578,15 @@
   }
 
   .status-tag-illegal {
-    color: #fff;
-    background: color-mix(in srgb, oklch(28% 0.12 12) 88%, transparent);
-    border-color: oklch(28% 0.12 12 / 0.75);
+    color: #ffffff;
+    background: color-mix(in srgb, oklch(28% 0.12 12deg) 88%, transparent);
+    border-color: oklch(28% 0.12 12deg / 0.75);
   }
 
   [data-theme="dark"] .status-tag-illegal {
-    color: oklch(91% 0.04 12);
-    background: color-mix(in srgb, oklch(42% 0.15 12) 22%, transparent);
-    border-color: color-mix(in srgb, oklch(55% 0.18 12) 50%, transparent);
+    color: oklch(91% 0.04 12deg);
+    background: color-mix(in srgb, oklch(42% 0.15 12deg) 22%, transparent);
+    border-color: color-mix(in srgb, oklch(55% 0.18 12deg) 50%, transparent);
   }
 
 /* ── 8. Country tag (hero / metadata badge) ──────────────────────────────── */
@@ -674,7 +675,7 @@
   .social-icons .btn:hover {
     transform: translateY(-3px) scale(1.08);
     border-color: transparent;
-    color: #fff;
+    color: #ffffff;
   }
 
 /* ── 10. Timeline ─────────────────────────────────────────────────────────── */
@@ -706,8 +707,8 @@
   /* Timeline dot and line markers */
   .bg-warning        { background-color: var(--color-warning) !important; }
   .bg-secondary-dot  { background-color: var(--text-secondary) !important; opacity: 0.5; }
-  .bg-illegal        { background-color: oklch(28% 0.12 12) !important; }
-  .shadow-illegal    { box-shadow: 0 0 10px oklch(28% 0.12 12 / 0.45); }
+  .bg-illegal        { background-color: oklch(28% 0.12 12deg) !important; }
+  .shadow-illegal    { box-shadow: 0 0 10px oklch(28% 0.12 12deg / 0.45); }
 
 /* ── 11. FAQ ──────────────────────────────────────────────────────────────── */
 
@@ -912,7 +913,7 @@
 
   /* Shadows */
   .shadow-sm {
-    box-shadow: 0 1px 3px 0 oklch(14% 0.02 248 / 0.08) !important;
+    box-shadow: 0 1px 3px 0 oklch(14% 0.02 248deg / 0.08) !important;
   }
 
   /* Typography */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -27,6 +27,7 @@
   /* Elevation scale — flat → card → raised → pop */
   --shadow-flat: 0 1px 2px rgb(20 23 31 / 0.04);
   --shadow-raised: 0 4px 8px rgb(20 23 31 / 0.06), 0 16px 32px -16px rgb(20 23 31 / 0.28);
+
   /* --shadow-card and --shadow-pop are defined in theme.css */
 }
 
@@ -135,6 +136,7 @@ main > *:not(header) {
 [data-theme="dark"] .counter .number { color: var(--color-breach-400); }
 
 /* ── navbar-expand-lg (Bootstrap replacement) ────────────────────────────── */
+
 /* Hide nav panel on mobile by default; show toggler. */
 @media (max-width: 991.98px) {
   .collapse.navbar-collapse {
@@ -777,7 +779,7 @@ main > *:not(header) {
   font-weight: 800;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: #fff;
+  color: #ffffff;
   background: var(--color-ink-600);
   padding: 0.2rem 0.5rem;
   border-radius: 4px;
@@ -944,7 +946,7 @@ main > *:not(header) {
   font-weight: 800;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: #fff;
+  color: #ffffff;
   background: var(--color-lawful-600);
   padding: 0.2rem 0.55rem;
   border-radius: 4px;
@@ -1070,7 +1072,7 @@ main > *:not(header) {
   font-weight: 800;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: #fff;
+  color: #ffffff;
   background: var(--color-breach-600);
   padding: 0.2rem 0.55rem;
   border-radius: 4px;
@@ -1166,6 +1168,7 @@ main > *:not(header) {
 [data-theme="dark"] #sistema {
   background: color-mix(in srgb, var(--color-brand-400) 8%, var(--bg-body)) !important;
 }
+
 /* Accessible, consistent keyboard focus ring across the site. */
 a:focus-visible,
 button:focus-visible,
@@ -1301,8 +1304,8 @@ summary:focus-visible,
   /* Force white canvas — override radial-gradient on body */
   html,
   body {
-    background: #fff !important;
-    color: #111 !important;
+    background: #ffffff !important;
+    color: #111111 !important;
     font-size: 11pt;
   }
 
@@ -1321,8 +1324,8 @@ summary:focus-visible,
   .org-card,
   .qf-inner {
     box-shadow: none !important;
-    border: 1px solid #ccc !important;
-    background: #fff !important;
+    border: 1px solid #cccccc !important;
+    background: #ffffff !important;
   }
 
   /* Bar chart colours: tell printer to honour */
@@ -1339,7 +1342,7 @@ summary:focus-visible,
   .irreg-block a[href^="http"]::after {
     content: " (" attr(href) ")";
     font-size: 0.7em;
-    color: #555;
+    color: #555555;
     word-break: break-all;
   }
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -13,9 +13,10 @@
  */
 
 @layer theme, base, components, utilities;
-@import "tailwindcss/theme.css"    layer(theme);
-@import "tailwindcss/preflight.css" layer(base);
-@import "tailwindcss/utilities.css" layer(utilities);
+
+@import url("tailwindcss/theme.css")    layer(theme);
+@import url("tailwindcss/preflight.css") layer(base);
+@import url("tailwindcss/utilities.css") layer(utilities);
 
 /* ── Dark mode variant — selector on <html> (matches theme-init.js) ───────── */
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
@@ -24,22 +25,25 @@
 @property --color-bg-body {
   syntax: "<color>";
   inherits: true;
-  initial-value: oklch(98% 0.004 80);        /* ≈ #f6f5f1 paper */
+  initial-value: oklch(98% 0.004 80deg);        /* ≈ #f6f5f1 paper */
 }
+
 @property --color-bg-card {
   syntax: "<color>";
   inherits: true;
-  initial-value: oklch(100% 0 0);             /* white */
+  initial-value: oklch(100% 0 0deg);             /* white */
 }
+
 @property --color-text-primary {
   syntax: "<color>";
   inherits: true;
-  initial-value: oklch(14% 0.01 248);         /* ≈ #14171f ink-900 */
+  initial-value: oklch(14% 0.01 248deg);         /* ≈ #14171f ink-900 */
 }
+
 @property --color-text-secondary {
   syntax: "<color>";
   inherits: true;
-  initial-value: oklch(40% 0.016 248);        /* ≈ #515868 ink-600 */
+  initial-value: oklch(40% 0.016 248deg);        /* ≈ #515868 ink-600 */
 }
 
 @theme {
@@ -104,7 +108,6 @@
   --font-display: "Sora", ui-sans-serif, system-ui, sans-serif;
   --font-sans:    "Source Sans 3", ui-sans-serif, system-ui, sans-serif;
   --font-mono:    ui-monospace, "SFMono-Regular", "Menlo", monospace;
-
   --tracking-tightest: -0.04em;
   --tracking-label:     0.14em;
 
@@ -113,9 +116,9 @@
   --radius-pill: 999px;
 
   /* ── Shadows (border-first Cactus approach — lighter than before) ────── */
-  --shadow-card: 0 1px 2px oklch(14% 0.01 248 / 0.04),
-                 0 4px 16px -8px oklch(14% 0.01 248 / 0.14);
-  --shadow-pop:  0 12px 40px -16px oklch(13% 0.05 248 / 0.35);
+  --shadow-card: 0 1px 2px oklch(14% 0.01 248deg / 0.04),
+                 0 4px 16px -8px oklch(14% 0.01 248deg / 0.14);
+  --shadow-pop:  0 12px 40px -16px oklch(13% 0.05 248deg / 0.35);
 
   /* ── Section rhythm ──────────────────────────────────────────────────── */
   --spacing-section: 4.5rem;


### PR DESCRIPTION
## What changed

- Applied Stylelint's safe automatic CSS fixes.
- Allowed the repository's existing BEM class convention.
- Added narrow compatibility exceptions for Tailwind directives, intentional specificity, compact utility rules, and the required WebKit backdrop-filter fallback.

## Root cause

`stylelint-config-standard` was enabled against existing Tailwind/BEM CSS without matching project-specific rules, leaving the default branch with 140 lint errors.

## Impact

The CI lint gate now passes. The CSS changes normalize equivalent syntax such as full hex colors and explicit hue units; application behavior is unchanged.

## Validation

- `npm run lint`
- `npm run build`
- `npx lhci autorun --upload.target=temporary-public-storage` — 12 Lighthouse runs passed across four routes
- `git diff --check`

## Rollback

Revert this commit.
